### PR TITLE
Set version to dev pre-release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as readme:
 
 setuptools.setup(
     name="exonum-python-client",
-    version="0.4.0",
+    version="0.4.0.dev1",
     author="The Exonum team",
     author_email="contact@exonum.com",
     description="Exonum Python Light Client",


### PR DESCRIPTION
With such a postfix, client can be uploaded to the `pypi` but will be somewhat hidden: it will not be installed by default with `pip install exonum-python-client`, only if concrete version will be specified.