### PR TITLE
Add --no-binary=protobuf to defaults in requiremets.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ First of all we need to install our client library:
 
 ```shell
 git clone git@github.com:exonum/exonum-python-client.git
-pip3 install -e exonum-python-client
+pip3 install -e exonum-python-client --no-binary=protobuf
 ```
 
 ### Exonum Client Initialization

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ mypy-extensions==0.4.1
 packaging==19.2
 pkginfo==1.5.0.1
 pluggy==0.13.0
-protobuf==3.9.2
+protobuf==3.9.2 --no-binary=protobuf
 py==1.8.0
 Pygments==2.4.2
 pylint==2.4.2


### PR DESCRIPTION
This PR makes dependencies installed from `requirements.txt` use `--no-binary=protobuf` by default.

Install via `setup.py` should use `pip install -e . --no-binary=protobuf` still though.