### PR TITLE
Raw proof map [ECR-3883]

### DIFF
--- a/examples/proofs.py
+++ b/examples/proofs.py
@@ -55,7 +55,6 @@ def run() -> None:
         expected_to_wallet_hash_raw = wallet_info["wallet_proof"]["to_table"]["entries"][0]["value"]
         expected_to_wallet_hash = Hash(bytes.fromhex(expected_to_wallet_hash_raw))
 
-        # TODO: verification of the proof to wallet fails because [ECR-3883]
         # Verify the proof to the wallet:
         verify_proof_to_wallet(proof_to_wallet, expected_to_wallet_hash)
 
@@ -114,7 +113,7 @@ def verify_proof_to_wallet(proof: Dict[Any, Any], expected_hash: Hash) -> None:
     value_encoder = build_encoder_function(cryptocurrency_module.Wallet)
 
     try:
-        parsed_proof = MapProof.parse(proof, key_encoder, value_encoder)
+        parsed_proof = MapProof.parse(proof, key_encoder, value_encoder, raw=True)
 
         result = parsed_proof.check()
 

--- a/exonum_client/proofs/map_proof/errors.py
+++ b/exonum_client/proofs/map_proof/errors.py
@@ -2,6 +2,8 @@
 from typing import Dict, Any
 from enum import Enum, auto as enum_auto
 
+from .constants import KEY_SIZE
+
 # Methods are self-documenting here.
 # pylint: disable=missing-docstring
 
@@ -17,6 +19,7 @@ class MalformedMapProofError(Exception):
         INVALID_ORDERING = enum_auto()
         NON_TERMINAL_NODE = enum_auto()
         MALFORMED_ENTRY = enum_auto()
+        INVALID_KEY_SIZE = enum_auto()
 
     def __init__(self, message: str, error_data: Dict[str, Any]) -> None:
         super().__init__(message)
@@ -57,6 +60,14 @@ class MalformedMapProofError(Exception):
         if additional_info:
             error_msg += " [{}]".format(additional_info)
         error_data = {"kind": cls.ErrorKind.MALFORMED_ENTRY, "entry": entry}
+
+        return cls(error_msg, error_data)
+
+    @classmethod
+    def invalid_key_size(cls, key: bytes) -> "MalformedMapProofError":
+        error_msg = f"Invalid key '{key}' for raw MapProof, expected size {KEY_SIZE}, actual {len(key)}"
+
+        error_data = {"kind": cls.ErrorKind.INVALID_KEY_SIZE, "key": key}
 
         return cls(error_msg, error_data)
 

--- a/exonum_client/proofs/map_proof/map_proof.py
+++ b/exonum_client/proofs/map_proof/map_proof.py
@@ -3,6 +3,7 @@ from typing import Optional, Dict, Any, List, Iterator, Callable
 from logging import getLogger
 
 from exonum_client.crypto import Hash
+from .constants import KEY_SIZE
 from .proof_path import ProofPath
 from .errors import MalformedMapProofError
 from .optional_entry import OptionalEntry
@@ -179,6 +180,7 @@ class MapProof:
         proof: List[_MapProofEntry],
         key_to_bytes: Callable[[Any], bytes],
         value_to_bytes: Callable[[Any], bytes],
+        raw: bool = False,
     ):
         """
         Constructor of MapProof. Do not call it directly, use `MapProof.parse`.
@@ -187,6 +189,7 @@ class MapProof:
         self.proof = proof
         self._key_to_bytes = key_to_bytes
         self._value_to_bytes = value_to_bytes
+        self._raw = raw
 
     def __repr__(self) -> str:
         format_str = "MapProof [\n  Entries: {}\n  Proof: {}\n]\n"
@@ -195,7 +198,10 @@ class MapProof:
 
     @staticmethod
     def parse(
-        data: Dict[str, Any], key_to_bytes: Callable[[Any], bytes], value_to_bytes: Callable[[Any], bytes]
+        data: Dict[str, Any],
+        key_to_bytes: Callable[[Any], bytes],
+        value_to_bytes: Callable[[Any], bytes],
+        raw: bool = False,
     ) -> "MapProof":
         """
         Method to parse a proof.
@@ -258,7 +264,7 @@ class MapProof:
         entries: List[OptionalEntry] = [OptionalEntry.parse(raw_entry) for raw_entry in data["entries"]]
         proof: List[_MapProofEntry] = [_MapProofEntry.parse(raw_entry) for raw_entry in data["proof"]]
 
-        map_proof = MapProof(entries, proof, key_to_bytes, value_to_bytes)
+        map_proof = MapProof(entries, proof, key_to_bytes, value_to_bytes, raw)
         logger.debug("Successfully built MapProof from the given proof dictionary.")
         return map_proof
 
@@ -301,9 +307,16 @@ class MapProof:
 
         def kv_to_map_entry(key_value: OptionalEntry) -> _MapProofEntry:
             key_bytes = self._key_to_bytes(key_value.key)
-            key_hash = Hasher.hash_raw_data(key_bytes)
+            if self._raw:
+                # For raw map proof keys aren't hashed.
+                if len(key_bytes) != KEY_SIZE:
+                    raise MalformedMapProofError.invalid_key_size(key_bytes)
+                key = key_bytes
+            else:
+                # For usual proofs we need to hash the key.
+                key = Hasher.hash_raw_data(key_bytes).value
 
-            path = ProofPath.from_bytes(key_hash.value)
+            path = ProofPath.from_bytes(key)
             value_hash = Hasher.hash_leaf(self._value_to_bytes(key_value.value))
 
             return _MapProofEntry(path, value_hash)

--- a/exonum_client/proofs/map_proof/map_proof.py
+++ b/exonum_client/proofs/map_proof/map_proof.py
@@ -244,6 +244,10 @@ class MapProof:
             Function that will be used to convert keys to bytes.
         value_to_bytes: Callable[[Any], bytes]
             Function that will be used to convert values to bytes.
+        raw: bool
+            Denotes if type of the proof is `RawMapProof` (meaning that key should not be hashed and
+            maps directly to the `ProofPath`).
+            Defaults to `False`.
 
         Returns
         -------

--- a/exonum_client/proofs/map_proof/map_proof_builder.py
+++ b/exonum_client/proofs/map_proof/map_proof_builder.py
@@ -34,10 +34,11 @@ class MapProofBuilder:
     returns a converter function.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, raw: bool = False) -> None:
         """ Constructor of MapProofBuilder. """
         self._key_encoder: Optional[type] = None
         self._value_encoder: Optional[type] = None
+        self._raw = raw
 
     @staticmethod
     def _get_encoder(
@@ -168,4 +169,4 @@ class MapProofBuilder:
         key_encoder_func = build_encoder_function(self._key_encoder)
         value_encoder_func = build_encoder_function(self._value_encoder)
 
-        return MapProof.parse(proof, key_encoder_func, value_encoder_func)
+        return MapProof.parse(proof, key_encoder_func, value_encoder_func, self._raw)

--- a/exonum_client/proofs/map_proof/map_proof_builder.py
+++ b/exonum_client/proofs/map_proof/map_proof_builder.py
@@ -26,6 +26,10 @@ class MapProofBuilder:
     >>> proof_builder.set_value_encoder('Wallet', service_name='cryptocurrency', service_module='service')
     >>> proof = proof_builder.build_proof(map_proof)
 
+    If the proof is built from `RawProofMapIndex`, you can provide bool `raw` variable to the constructor:
+
+    >>> proof_builder = MapProofBuilder(raw=True)
+
     If your key/value type does not require convertion to bytes through Protobuf, use `MapProof.parse`
     instead and provide your converter functions by yourself.
 

--- a/tests/test_map_proof.py
+++ b/tests/test_map_proof.py
@@ -338,3 +338,49 @@ class TestMapProof(PrecompiledModuleUserTestCase):
         expected_hash = "3ccac1646fbbbc7e22a70b2a426c0d22bdde14a03f4ffc3547207245a4774afc"
 
         self.assertEqual(result.root_hash().hex(), expected_hash)
+
+    def test_raw_map_proof(self):
+        proof = {
+            "entries": [
+                {
+                    "key": "85a2386718cd07204f6b043531923be28ef9265584b113f4c509dfcd004ed0b6",
+                    "value": {
+                        "pub_key": {
+                            "data": list(
+                                bytes.fromhex("85a2386718cd07204f6b043531923be28ef9265584b113f4c509dfcd004ed0b6")
+                            )
+                        },
+                        "name": "Alice",
+                        "balance": 100,
+                        "history_len": 1,
+                        "history_hash": {
+                            "data": list(
+                                bytes.fromhex("a7e4c01c666f8eca6d8bc994ee65d947a5e80e857d4bda8b59deb2a8388431f3")
+                            )
+                        },
+                    },
+                }
+            ],
+            "proof": [
+                {"path": "0", "hash": "859a29b78999f8e068f7fc194f0553a56cd8d07b0e09dc71dfea7d815e0d662c"},
+                {
+                    "path": "10000001000000100111000110000011011100111010101001011011000101100111111011100001001000110"
+                    "00000010110000011001111110011100010110001101101000000000010011110101100001000011101001000"
+                    "101001110110111111111101101100110011101111010001011010110100010001110101101101",
+                    "hash": "5f176f6f98e83934c87679999822533c6d173b750b0ff8f0e38a54f65a3d84e2",
+                },
+            ],
+        }
+
+        cryptocurrency_service_name = "exonum-cryptocurrency-advanced:0.11.0"
+        cryptocurrency_module = ModuleManager.import_service_module(cryptocurrency_service_name, "service")
+
+        cryptocurrency_decoder = build_encoder_function(cryptocurrency_module.Wallet)
+
+        parsed_proof = MapProof.parse(proof, bytes.fromhex, cryptocurrency_decoder, raw=True)
+
+        result = parsed_proof.check()
+
+        expected_hash = "d3de42248cfa078d94861defe11e39176b2e91fa2ad24be96d44977457691e19"
+
+        self.assertEqual(result.root_hash().hex(), expected_hash)


### PR DESCRIPTION
This PR add support of raw map proofs (ones that don't require key to be hashed, and just map key bytes to the `ProofPath`).