### PR TITLE
Use compressed paths for a single map entry in map proofs

### DIFF
--- a/exonum_client/crypto.py
+++ b/exonum_client/crypto.py
@@ -30,7 +30,7 @@ class _FixedByteArray:
         if len(data) != expected_len:
             raise ValueError(f"Incorrect data length: expected {expected_len}, got {len(data)}.")
 
-        self.value = data
+        self.value: bytes = bytes(data)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _FixedByteArray):

--- a/exonum_client/proofs/map_proof/map_proof.py
+++ b/exonum_client/proofs/map_proof/map_proof.py
@@ -89,7 +89,7 @@ def collect(entries: List[_MapProofEntry]) -> Hash:
             logger.warning(str(err))
             raise err
 
-        return Hasher.hash_single_entry_map(entries[0].path.as_bytes(), entries[0].hash)
+        return Hasher.hash_single_entry_map(entries[0].path.as_bytes_compressed(), entries[0].hash)
 
     # There is more than 1 entry.
 


### PR DESCRIPTION
These changes actualize map proofs verification process to match one introduced in https://github.com/exonum/exonum/pull/1743