### PR TITLE
Protobuf provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       script:
         - black --check -l 120 . --exclude=".*_pb2.py"
         - mypy --ignore-missing-imports --disallow-untyped-defs ./exonum_client ./examples
-        - pylint exonum_client --max-line-length=120 --disable=fixme,bad-continuation,too-few-public-methods
+        - pylint exonum_client --max-line-length=120 --disable=fixme,bad-continuation,too-few-public-methods,R0801
     - name: docs
       install:
         - pip install sphinx

--- a/examples/custom_protobuf_source.py
+++ b/examples/custom_protobuf_source.py
@@ -1,0 +1,81 @@
+"""Custom Protobuf Source Example.
+
+This example shows how to use Exonum Python light client with custom protobuf sources.
+In this file, we will make light client compile protobuf sources for version 0.12 (instead
+of actual one).
+
+Though this may be not really useful (since light client itself is not compatible with Exonum
+0.12), it can be extrapolated to other use cases, e.g. work with other runtimes that do not
+support obtaining protobuf sources from REST API.
+"""
+from exonum_client.protobuf_provider import ProtobufProvider
+from exonum_client import ExonumClient, ModuleManager
+
+RUST_RUNTIME_ID = 0
+SERVICE_VERSION = "0.12"
+
+
+def setup_protobuf_provider(protobuf_provider: ProtobufProvider) -> None:
+    """Setups a protobuf provider with main protobuf sources and cryptocurrency-advanced sources for v0.12.
+
+    Exonum client creates a ProtobufProvider object during its initialization, so we take it here
+    and just extend with new sources."""
+    main_sources_url = "https://github.com/exonum/exonum/tree/v0.12/exonum/src/proto/schema/exonum"
+    cryptocurrency_sources_url = (
+        "https://github.com/exonum/exonum/tree/v0.12/examples/cryptocurrency-advanced/backend/src/proto"
+    )
+    protobuf_provider.add_main_source(main_sources_url)
+    protobuf_provider.add_service_source(cryptocurrency_sources_url, "cryptocurrency-advanced", SERVICE_VERSION)
+
+
+def run() -> None:
+    """Example of downloading the Protobuf sources and using the compiled
+    module."""
+
+    # Create client.
+    client = ExonumClient(hostname="127.0.0.1", public_api_port=8080, private_api_port=8081)
+
+    # Setup protobuf provider.
+    setup_protobuf_provider(client.protobuf_provider)
+
+    # Create ProtobufLoader via context manager (so that we will not have to
+    # initialize/deinitialize it manually):
+    with client.protobuf_loader() as loader:
+        # Load core proto files:
+        loader.load_main_proto_files()
+        # Load proto files for the Exonum supervisor service:
+        loader.load_service_proto_files(RUST_RUNTIME_ID, "cryptocurrency-advanced", SERVICE_VERSION)
+
+        # Load the main module (helpers.proto).
+        helpers_module = ModuleManager.import_main_module("helpers")
+
+        # Create a Protobuf message object:
+        public_key = helpers_module.PublicKey()
+        public_key.data = bytes(i for i in range(32))
+
+        # Load the service module (cryptocurrency.proto from the cryptocurrency-advanced service).
+        # Note that we load "cryptocurrency" module, which is absent in current version
+        # of service, it only exists in Exonum 0.12.
+        service_module = ModuleManager.import_service_module(
+            "cryptocurrency-advanced", SERVICE_VERSION, "cryptocurrency"
+        )
+        # Note that if we want to work with service module, we should use helpers also from that module.
+        # That's required because of the inner python Protobuf implementation check system.
+        cryptocurrency_helpers_module = ModuleManager.import_service_module(
+            "cryptocurrency-advanced", SERVICE_VERSION, "helpers"
+        )
+
+        # Workflow is the same as for the main modules:
+        transfer = service_module.Transfer()
+        cryptocurrency_public_key = cryptocurrency_helpers_module.PublicKey()
+        cryptocurrency_public_key.data = bytes(i for i in range(32))
+
+        # Working with Protobuf objects, you have to follow Protobuf Python API conventions.
+        # See Protobuf Python API docs for details.
+        transfer.to.CopyFrom(cryptocurrency_public_key)
+        transfer.amount = 10
+        transfer.seed = 1
+
+
+if __name__ == "__main__":
+    run()

--- a/exonum_client/api.py
+++ b/exonum_client/api.py
@@ -1,9 +1,8 @@
 """
 Exonum API Module.
 
-This module provides 4 classes classes:
+This module provides several API classes:
   - Api: a class with basic REST functionality.
-  - ProtobufApi: a class that implements ProtobufProviderInterface interface.
   - PublicApi: a subclass of class Api that provides methods to interact with public API of an Exonum node.
   - PrivateApi: a subclass of class Api that provides methods to interact with private API of an Exonum node.
   - ServiceApi: a class that provides methods to interact with node services.
@@ -14,7 +13,6 @@ import json
 from logging import getLogger
 import requests
 
-from .protobuf_loader import ProtoFile, ProtobufProviderInterface
 from .message import ExonumMessage
 
 # pylint: disable=C0103
@@ -55,52 +53,6 @@ class Api:
     def post(url: str, data: str, headers: Dict[str, str]) -> requests.Response:
         """Internal wrapper over requests.post"""
         return requests.post(url, data=data, headers=headers)
-
-
-class ProtobufApi(Api, ProtobufProviderInterface):
-    """ProtobufApi class implements ProtobufProviderInterface interface."""
-
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
-
-        self._rust_runtime_url = self.endpoint_prefix + "/runtimes/rust/{}"
-
-    def _get_proto_sources(self, params: Optional[Dict[str, str]] = None) -> List[ProtoFile]:
-        """Retrieves protobuf sources."""
-        proto_sources_endpoint = self._rust_runtime_url.format("proto-sources")
-        response = self.get(proto_sources_endpoint, params=params)
-        if response.status_code != 200 or "application/json" not in response.headers["content-type"]:
-            logger.critical(
-                "Unsuccessfully attempted to retrieve Protobuf sources.\n" "Status code: %s,\n" "body:\n%s",
-                response.status_code,
-                response.content,
-            )
-            raise RuntimeError("Unsuccessfully attempted to retrieve Protobuf sources: {!r}".format(response.content))
-        logger.debug("Protobuf sources retrieved successfully.")
-
-        proto_files = [
-            ProtoFile(name=proto_file["name"], content=proto_file["content"]) for proto_file in response.json()
-        ]
-
-        return proto_files
-
-    def get_main_proto_sources(self) -> List[ProtoFile]:
-        """Performs a GET request to the `proto-sources` Exonum endpoint."""
-        params = {"type": "core"}
-        return self._get_proto_sources(params)
-
-    def get_proto_sources_for_artifact(
-        self, runtime_id: int, artifact_name: str, artifact_version: str
-    ) -> List[ProtoFile]:
-        """Raise an exception if runtime ID is not equal to the rust runtime ID."""
-        if runtime_id != self.RUST_RUNTIME_ID:
-            err_msg = f"Provided runtime ID: {runtime_id} is not equal to Rust runtime ID: {self.RUST_RUNTIME_ID}."
-            logger.critical(err_msg)
-            raise RuntimeError(err_msg)
-        # Performs a GET request to the `proto-sources` Exonum endpoint with a provided artifact name:
-        params = {"type": "artifact", "name": artifact_name, "version": artifact_version}
-
-        return self._get_proto_sources(params)
 
 
 class PublicApi(Api):

--- a/exonum_client/client.py
+++ b/exonum_client/client.py
@@ -216,6 +216,8 @@ class ExonumClient:
 
     >>> client.protobuf_provider.add_fallback_provider(your_runtime_id, your_protobuf_provider)
 
+    "your_protobuf_provider" should be an object of class that derives ProtobufProviderInterface.
+
     # More Usage Examples
 
     To see more examples of ExonumClient class usage, visit the project GitHub page:

--- a/exonum_client/client.py
+++ b/exonum_client/client.py
@@ -157,7 +157,7 @@ class Subscriber:
 class ExonumClient:
     """ExonumClient class is capable of interaction with ExonumBlockchain.
 
-    This class provides functionality to interact with Exonum node via either
+    This class provides functionality to interact with the Exonum node via either
     HTTP API or websockets.
 
     # API Interaction
@@ -192,8 +192,8 @@ class ExonumClient:
 
     # Obtaining Protobuf Sources
 
-    By default, ExonumClient tries to obtain protobuf files required to interact with service
-    using the REST API of Exonum node. This works for Rust runtime services only though.
+    By default, ExonumClient tries to obtain protobuf files required to interact with a service
+    using the REST API of the Exonum node. This works for the Rust runtime services only though.
 
     To be able to interact with other runtimes, one can add either sources for certain services,
     or add a generic protobuf provider for a runtime.
@@ -220,7 +220,7 @@ class ExonumClient:
 
     # More Usage Examples
 
-    To see more examples of ExonumClient class usage, visit the project GitHub page:
+    To see more examples of the ExonumClient class usage, visit the project GitHub page:
     https://github.com/exonum/exonum-python-client
     """
 

--- a/exonum_client/client.py
+++ b/exonum_client/client.py
@@ -204,7 +204,7 @@ class ExonumClient:
     >>> client.protobuf_provider.add_service_source(service_sources_url, "some-service", "0.1.0")
 
     Here we tell the client to lookup sources for service named "some-service" with version 0.1.0
-    on GitHub. Path should lead to the folder that contains "*.proto" files.
+    on GitHub. Path should lead to the folder that contains "\*.proto" files.
 
     Also we can use the local filesystem instead of GitHub:
 

--- a/exonum_client/client.py
+++ b/exonum_client/client.py
@@ -204,7 +204,7 @@ class ExonumClient:
     >>> client.protobuf_provider.add_service_source(service_sources_url, "some-service", "0.1.0")
 
     Here we tell the client to lookup sources for service named "some-service" with version 0.1.0
-    on GitHub. Path should lead to the folder that contains "\*.proto" files.
+    on GitHub. Path should lead to the folder that contains "\\*.proto" files.
 
     Also we can use the local filesystem instead of GitHub:
 

--- a/exonum_client/client.py
+++ b/exonum_client/client.py
@@ -157,6 +157,11 @@ class Subscriber:
 class ExonumClient:
     """ExonumClient class is capable of interaction with ExonumBlockchain.
 
+    This class provides functionality to interact with Exonum node via either
+    HTTP API or websockets.
+
+    # API Interaction
+
     All the methods that perform requests to the Exonum REST API return a requests.Response object.
     So a user should manually verify that the status code of the request is correct and get the contents
     of the request via `response.json()`.
@@ -171,6 +176,50 @@ class ExonumClient:
     {'consensus_status': 'Enabled', 'connected_peers': 0}
     >>> user_agent = client.public_api.user_agent().json()
     exonum 0.13.0-rc.2/rustc 1.37.0 (eae3437df 2019-08-13)
+
+    # Websocket interaction
+
+    To interact with the Exonum node via webscokets, one should create a Subscriber object.
+    Subscriber objects are managed via context managers, so the connection is correctly opened
+    and closed on exit. User can subscribe to either block or transactions events.
+
+    Example:
+
+    >>> with client.create_subscriber("blocks") as subscriber:
+    >>>     subscriber.wait_for_new_event()
+
+    For more information, see the Subscriber class documentation.
+
+    # Obtaining Protobuf Sources
+
+    By default, ExonumClient tries to obtain protobuf files required to interact with service
+    using the REST API of Exonum node. This works for Rust runtime services only though.
+
+    To be able to interact with other runtimes, one can add either sources for certain services,
+    or add a generic protobuf provider for a runtime.
+
+    Adding sources for a service will look as follows:
+
+    >>> service_sources_url = "https://github.com/organization/project/path/to/sources"
+    >>> client.protobuf_provider.add_service_source(service_sources_url, "some-service", "0.1.0")
+
+    Here we tell the client to lookup sources for service named "some-service" with version 0.1.0
+    on GitHub. Path should lead to the folder that contains "*.proto" files.
+
+    Also we can use the local filesystem instead of GitHub:
+
+    >>> service_sources_path = "/path/on/local/filesystem"
+    >>> client.protobuf_provider.add_service_source(service_sources_path, "some-service", "0.1.0")
+
+    Other way to interact with non-Rust services is to specify a "fallback" provider which will be
+    used if service runtime is not Rust, and there is no separate source configured for the service:
+
+    >>> client.protobuf_provider.add_fallback_provider(your_runtime_id, your_protobuf_provider)
+
+    # More Usage Examples
+
+    To see more examples of ExonumClient class usage, visit the project GitHub page:
+    https://github.com/exonum/exonum-python-client
     """
 
     def __init__(self, hostname: str, public_api_port: int = 80, private_api_port: int = 81, ssl: bool = False):

--- a/exonum_client/protobuf_provider/__init__.py
+++ b/exonum_client/protobuf_provider/__init__.py
@@ -1,0 +1,4 @@
+"""Protobuf sources provider module."""
+
+from exonum_client.protobuf_provider.provider import ProtobufProvider
+from exonum_client.protobuf_provider.exonum_api import ExonumApiProvider

--- a/exonum_client/protobuf_provider/exonum_api.py
+++ b/exonum_client/protobuf_provider/exonum_api.py
@@ -1,3 +1,9 @@
+"""This module introduces an ExonumApiProvider class, which is capable
+of loading core protobuf files and protobuf files for Rust runtime via
+Exonum node REST API.
+
+This provider is enabled by default.
+"""
 from typing import Optional, Any, List, Dict
 
 from logging import getLogger

--- a/exonum_client/protobuf_provider/exonum_api.py
+++ b/exonum_client/protobuf_provider/exonum_api.py
@@ -1,0 +1,55 @@
+from typing import Optional, Any, List, Dict
+
+from logging import getLogger
+
+from exonum_client.protobuf_loader import ProtoFile, ProtobufProviderInterface
+from exonum_client.api import Api
+
+# pylint: disable=C0103
+logger = getLogger(__name__)
+
+
+class ExonumApiProvider(Api, ProtobufProviderInterface):
+    """ProtobufApi class implements ProtobufProviderInterface interface."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+        self._rust_runtime_url = self.endpoint_prefix + "/runtimes/rust/{}"
+
+    def _get_proto_sources(self, params: Optional[Dict[str, str]] = None) -> List[ProtoFile]:
+        """Retrieves protobuf sources."""
+        proto_sources_endpoint = self._rust_runtime_url.format("proto-sources")
+        response = self.get(proto_sources_endpoint, params=params)
+        if response.status_code != 200 or "application/json" not in response.headers["content-type"]:
+            logger.critical(
+                "Unsuccessfully attempted to retrieve Protobuf sources.\n" "Status code: %s,\n" "body:\n%s",
+                response.status_code,
+                response.content,
+            )
+            raise RuntimeError("Unsuccessfully attempted to retrieve Protobuf sources: {!r}".format(response.content))
+        logger.debug("Protobuf sources retrieved successfully.")
+
+        proto_files = [
+            ProtoFile(name=proto_file["name"], content=proto_file["content"]) for proto_file in response.json()
+        ]
+
+        return proto_files
+
+    def get_main_proto_sources(self) -> List[ProtoFile]:
+        """Performs a GET request to the `proto-sources` Exonum endpoint."""
+        params = {"type": "core"}
+        return self._get_proto_sources(params)
+
+    def get_proto_sources_for_artifact(
+        self, runtime_id: int, artifact_name: str, artifact_version: str
+    ) -> List[ProtoFile]:
+        """Raise an exception if runtime ID is not equal to the rust runtime ID."""
+        if runtime_id != self.RUST_RUNTIME_ID:
+            err_msg = f"Provided runtime ID: {runtime_id} is not equal to Rust runtime ID: {self.RUST_RUNTIME_ID}."
+            logger.critical(err_msg)
+            raise RuntimeError(err_msg)
+        # Performs a GET request to the `proto-sources` Exonum endpoint with a provided artifact name:
+        params = {"type": "artifact", "name": artifact_name, "version": artifact_version}
+
+        return self._get_proto_sources(params)

--- a/exonum_client/protobuf_provider/filesystem.py
+++ b/exonum_client/protobuf_provider/filesystem.py
@@ -1,0 +1,48 @@
+"""Protobuf provider which loads .proto files from the filesystem."""
+
+from typing import List, Optional
+import os
+
+from exonum_client.protobuf_loader import ProtobufProviderInterface, ProtoFile
+
+
+class _FilesystemProtobufProvider(ProtobufProviderInterface):
+    def __init__(self, service_name: str, service_version: str, folder_path: str) -> None:
+        if not os.path.isdir(folder_path):
+            raise ValueError(f"Incorrect protobuf sources path: {folder_path}")
+
+        self._path = folder_path
+        self._is_main = not service_name  # True if None is provided.
+        if not self._is_main:
+            self._service_name = service_name
+            self._service_version = service_version
+
+    def get_main_proto_sources(self) -> List[ProtoFile]:
+        """Gets the Exonum core proto sources."""
+        if not self._is_main:
+            raise RuntimeError("Attempt to get main sources from source github repo")
+
+        return self._get_sources()
+
+    def get_proto_sources_for_artifact(
+        self, runtime_id: int, artifact_name: str, artifact_version: str
+    ) -> List[ProtoFile]:
+        """Gets the Exonum core proto sources."""
+        if self._is_main or self._service_name != artifact_name or self._service_version != artifact_version:
+            raise RuntimeError("Attempt to get sources for wrong artifact")
+
+        return self._get_sources()
+
+    def _get_sources(self) -> List[ProtoFile]:
+        result: List[ProtoFile] = []
+
+        for name in os.listdir(self._path):
+            if not name.endswith(".proto"):
+                continue
+
+            with open(os.path.join(self._path, name), "r") as proto_file:
+                file_content = proto_file.read()
+
+            result.append(ProtoFile(name=name, content=file_content))
+
+        return result

--- a/exonum_client/protobuf_provider/filesystem.py
+++ b/exonum_client/protobuf_provider/filesystem.py
@@ -1,6 +1,6 @@
 """Protobuf provider which loads .proto files from the filesystem."""
 
-from typing import List, Optional
+from typing import List
 import os
 
 from exonum_client.protobuf_loader import ProtobufProviderInterface, ProtoFile

--- a/exonum_client/protobuf_provider/github.py
+++ b/exonum_client/protobuf_provider/github.py
@@ -1,6 +1,6 @@
 """Protobuf provider which loads .proto files from GitHub."""
 
-from typing import List, Optional
+from typing import List
 import re
 
 import requests

--- a/exonum_client/protobuf_provider/github.py
+++ b/exonum_client/protobuf_provider/github.py
@@ -1,0 +1,65 @@
+"""Protobuf provider which loads .proto files from GitHub."""
+
+from typing import List, Optional
+import re
+
+import requests
+
+from exonum_client.protobuf_loader import ProtobufProviderInterface, ProtoFile
+
+
+class _GithubProtobufProvider(ProtobufProviderInterface):
+
+    GITHUB_URL_REGEX = re.compile(
+        r"https://github.com/(?P<organization>[\w.-]+)/(?P<repo>[\w.-]+)/tree/(?P<ref>[\w.-]+)/(?P<path>.+)"
+    )
+
+    def __init__(self, service_name: str, service_version: str, github_folder_path: str) -> None:
+        match = self.GITHUB_URL_REGEX.match(github_folder_path)
+
+        if not match:
+            raise RuntimeError(f"Invalid github folder path: {github_folder_path}")
+
+        self._organization = match.group("organization")
+        self._repo = match.group("repo")
+        self._ref = match.group("ref")
+        self._path = match.group("path")
+        self._is_main = service_name == "_main"
+        if not self._is_main:
+            self._service_name = service_name
+            self._service_version = service_version
+
+    def get_main_proto_sources(self) -> List[ProtoFile]:
+        """Gets the Exonum core proto sources."""
+        if not self._is_main:
+            raise RuntimeError("Attempt to get main sources from source specified as service")
+
+        return self._get_sources()
+
+    def get_proto_sources_for_artifact(
+        self, runtime_id: int, artifact_name: str, artifact_version: str
+    ) -> List[ProtoFile]:
+        """Gets the Exonum core proto sources."""
+        if self._is_main or self._service_name != artifact_name or self._service_version != artifact_version:
+            raise RuntimeError("Attempt to get sources for wrong artifact")
+
+        return self._get_sources()
+
+    def _get_sources(self) -> List[ProtoFile]:
+        content_url = (
+            f"https://api.github.com/repos/{self._organization}/{self._repo}/contents/{self._path}?ref={self._ref}"
+        )
+
+        content = requests.get(content_url)
+
+        result: List[ProtoFile] = []
+
+        for source_file in content.json():
+            name = source_file["name"]
+            if not name.endswith(".proto"):
+                continue
+            file_content = requests.get(source_file["download_url"]).content.decode("utf-8")
+
+            result.append(ProtoFile(name=name, content=file_content))
+
+        return result

--- a/exonum_client/protobuf_provider/provider.py
+++ b/exonum_client/protobuf_provider/provider.py
@@ -31,6 +31,8 @@ class ProtobufProvider(ProtobufProviderInterface):
     # TODO explain more.
     """
 
+    RUST_RUNTIME_ID = 0
+
     def __init__(self) -> None:
         """Constructor of the ProtobufProvider class."""
         self._lookup: Dict[str, ProtobufProviderInterface] = dict()
@@ -82,8 +84,7 @@ class ProtobufProvider(ProtobufProviderInterface):
         """Gets the Exonum core proto sources."""
         provider = self._lookup.get("_main_")
         if provider is None:
-            rust_runtime_id = 0
-            rust_runtime_provider = self._fallback.get(rust_runtime_id)
+            rust_runtime_provider = self._fallback.get(self.RUST_RUNTIME_ID)
             if rust_runtime_provider is None:
                 raise RuntimeError(
                     "Main sources provider is not set and \

--- a/exonum_client/protobuf_provider/provider.py
+++ b/exonum_client/protobuf_provider/provider.py
@@ -23,7 +23,7 @@ class ProtobufProvider(ProtobufProviderInterface):
     If for some request there will be no source set, `ProtobufProvider` will try to use
     a "fallback" provider, specific to the runtime.
 
-    E.g., for Rust runtime, sources will be obtained from the REST API provided by Exonum Rust
+    E.g., for the Rust runtime, sources will be obtained from the REST API provided by the Exonum Rust
     runtime API.
 
     If there is no fallback provider for the request's runtime, an exception will be raised.
@@ -46,7 +46,7 @@ class ProtobufProvider(ProtobufProviderInterface):
     def add_main_source(self, source_path: str) -> None:
         """Adds a main source for common Exonum protobuf files.
 
-        Note that currently there is no need to provide "main" source separately, as Exonum
+        Note that currently there is no need to provide "main" source separately, since Exonum
         node can provide them via API.
         """
 
@@ -56,7 +56,7 @@ class ProtobufProvider(ProtobufProviderInterface):
     def add_service_source(self, source_path: str, service_name: str, service_version: str) -> None:
         """Adds a source for Exonum service into ProtobufProvider.
 
-        Source must be either a filesystem path, or a GitHub url.
+        A source must be either a filesystem path, or a GitHub url.
 
         Examples:
 

--- a/exonum_client/protobuf_provider/provider.py
+++ b/exonum_client/protobuf_provider/provider.py
@@ -1,0 +1,113 @@
+"""Protobuf sources provider module."""
+
+from typing import Dict, List
+import os
+
+from exonum_client.protobuf_loader import ProtobufProviderInterface, ProtoFile
+from exonum_client.protobuf_provider.github import _GithubProtobufProvider
+from exonum_client.protobuf_provider.filesystem import _FilesystemProtobufProvider
+
+
+class ProtobufProvider(ProtobufProviderInterface):
+    """Protobuf Provider class.
+
+    It supports two types of receiving protobuf sources:
+
+    - via filesystem,
+    - via `github`,
+    - via external "fallback" providers.
+
+    This class is designed to obtain required Protobuf sources from different places.
+    For each service, user is able to add source from which `.proto` files will be obtained.
+
+    If for some request there will be no source set, `ProtobufProvider` will try to use
+    a "fallback" provider, specific to the runtime.
+
+    E.g., for Rust runtime, sources will be obtained from the REST API provided by Exonum Rust
+    runtime API.
+
+    If there is no fallback provider for the request's runtime, an exception will be raised.
+
+    # TODO explain more.
+    """
+
+    def __init__(self) -> None:
+        """Constructor of the ProtobufProvider class."""
+        self._lookup: Dict[str, ProtobufProviderInterface] = dict()
+        self._fallback: Dict[int, ProtobufProviderInterface] = dict()
+
+    def add_fallback_provider(self, runtime_id: int, fallback_probider: ProtobufProviderInterface) -> None:
+        """Adds a provider which will be used if provider for required service
+        was not found.
+        """
+
+        self._fallback[runtime_id] = fallback_probider
+
+    def add_main_source(self, source_path: str) -> None:
+        """Adds a main source for common Exonum protobuf files.
+
+        Note that currently there is no need to provide "main" source separately, as Exonum
+        node can provide them via API.
+        """
+
+        # Main sources will be stored in the lookup table as "_main_".
+        self.add_service_source(source_path, "_main", "")
+
+    def add_service_source(self, source_path: str, service_name: str, service_version: str) -> None:
+        """Adds a source for Exonum service into ProtobufProvider.
+
+        Source must be either a filesystem path, or a GitHub url.
+
+        Examples:
+
+        >>> provider = ProtobufProvider()
+        >>> main_sources_path = "https://github.com/exonum/exonum/tree/master/exonum/src/proto/schema/exonum"
+        >>> service_sources_path = "/home/user/service/proto_dir"
+        >>> provider.add_source(main_sources_path) # Add main sources from github.
+        >>> provider.add_source(service_sources_path, "service_name") # Add service sources from local folder.
+        """
+        verbose_service_name = f"{service_name}_{service_version}"
+
+        if self._lookup.get(verbose_service_name):
+            raise ValueError("Duplicate source")
+
+        if os.path.isdir(source_path):
+            self._lookup[verbose_service_name] = _FilesystemProtobufProvider(service_name, service_version, source_path)
+        elif source_path.startswith("https://github.com"):
+            self._lookup[verbose_service_name] = _GithubProtobufProvider(service_name, service_version, source_path)
+        else:
+            raise ValueError(f"Incorrect source path: {source_path}")
+
+    def get_main_proto_sources(self) -> List[ProtoFile]:
+        """Gets the Exonum core proto sources."""
+        provider = self._lookup.get("_main_")
+        if provider is None:
+            rust_runtime_id = 0
+            rust_runtime_provider = self._fallback.get(rust_runtime_id)
+            if rust_runtime_provider is None:
+                raise RuntimeError(
+                    "Main sources provider is not set and \
+                     Rust runtime provider is not available"
+                )
+
+            provider = rust_runtime_provider
+
+        return provider.get_main_proto_sources()
+
+    def get_proto_sources_for_artifact(
+        self, runtime_id: int, artifact_name: str, artifact_version: str
+    ) -> List[ProtoFile]:
+        """Gets the Exonum service proto sources."""
+        verbose_service_name = f"{artifact_name}_{artifact_version}"
+        provider = self._lookup.get(verbose_service_name)
+        if provider is None:
+            fallback_provider = self._fallback.get(runtime_id)
+            if fallback_provider is None:
+                raise RuntimeError(
+                    f"Souce provider for service '{artifact_name}' is not set, \
+                    and there is no fallback provider for runtime '{runtime_id}'"
+                )
+
+            provider = fallback_provider
+
+        return provider.get_proto_sources_for_artifact(runtime_id, artifact_name, artifact_version)

--- a/tests/test_protobuf_loader.py
+++ b/tests/test_protobuf_loader.py
@@ -77,14 +77,14 @@ class TestProtobufLoader(unittest.TestCase):
             with self.assertRaises(ValueError):
                 client_2.protobuf_loader()
 
-    @patch("exonum_client.api.ProtobufApi.get", new=mock_requests_get)
+    @patch("exonum_client.protobuf_provider.ExonumApiProvider.get", new=mock_requests_get)
     def test_main_sources_download(self):
         with self.client.protobuf_loader() as loader:
             loader.load_main_proto_files()
 
             _runtime_mod = ModuleManager.import_main_module("runtime")
 
-    @patch("exonum_client.api.ProtobufApi.get", new=mock_requests_get)
+    @patch("exonum_client.protobuf_provider.ExonumApiProvider.get", new=mock_requests_get)
     def test_service_sources_download(self):
         with self.client.protobuf_loader() as loader:
             loader.load_main_proto_files()


### PR DESCRIPTION
This is a farewell pull request.

This PR introduces a new entity named `ProtobufProvider`. This entity is capable of dynamically loading protobuf files on the fly.

By default, it behaves the same way as it worked before: files are obtained from the Exonum node via REST API.

However, with this entity, it is now possible to provide sources for a certain service, or even provide a brand new protobuf provider for a runtime.

Thus, with this PR client becomes compatible with runtimes other than Rust (*hi Java!*), and even if the support of obtaining protobuf sources from the node will be cut off, the client will remain as convenient as it is now.

So, with this PR merged, Python client will finally become a general-purpose library to interact with Exonum in **any** conditions.

:warning: **Warning**: Since today is my last work day in Exonum, I will try to resolve any review comments that this PR will receive until 16.00 UTC+3. After that, I have no plans to update this PR.

You can decide whether you want to give it a quick review, or merge it as-is, or even discard changes and close it. Any option is OK for me :)